### PR TITLE
Small performance improvement at startup time

### DIFF
--- a/MDC-111/ObjectiveC/Complete/Pods/MaterialComponents/components/private/KeyboardWatcher/src/MDCKeyboardWatcher.m
+++ b/MDC-111/ObjectiveC/Complete/Pods/MaterialComponents/components/private/KeyboardWatcher/src/MDCKeyboardWatcher.m
@@ -52,20 +52,21 @@ static MDCKeyboardWatcher *_sKeyboardWatcher;
 - (instancetype)init {
   self = [super init];
   if (self) {
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(keyboardWillShow:)
-                                                 name:UIKeyboardWillShowNotification
-                                               object:nil];
+    NSNotificationCenter *defaultCenter = [NSNotificationCenter defaultCenter];
+    [defaultCenter addObserver:self
+                      selector:@selector(keyboardWillShow:)
+                          name:UIKeyboardWillShowNotification
+                        object:nil];
 
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(keyboardWillHide:)
-                                                 name:UIKeyboardWillHideNotification
-                                               object:nil];
+    [defaultCenter addObserver:self
+                      selector:@selector(keyboardWillHide:)
+                          name:UIKeyboardWillHideNotification
+                        object:nil];
 
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(keyboardWillChangeFrame:)
-                                                 name:UIKeyboardWillChangeFrameNotification
-                                               object:nil];
+    [defaultCenter addObserver:self
+                      selector:@selector(keyboardWillChangeFrame:)
+                          name:UIKeyboardWillChangeFrameNotification
+                        object:nil];
   }
 
   return self;


### PR DESCRIPTION
Since you are paying for the cost of creating one of these things before main, do a little bit to reduce the overhead by removing two unnecessary calls. (Yes it did show up on a profile... and yes it is a microoptimization, but I don't think it detracts from the readability).