### PR TITLE
[111] Fix unsafe bounds access

### DIFF
--- a/MDC-111/ObjectiveC/Complete/MDC-111/ViewController.m
+++ b/MDC-111/ObjectiveC/Complete/MDC-111/ViewController.m
@@ -70,7 +70,8 @@
 - (void)viewDidLayoutSubviews {
   [super viewDidLayoutSubviews];
 
-  self.saveButton.hitAreaInsets = UIEdgeInsetsMake((48 - self.saveButton.bounds.size.height) / -2, 0, (48 - self.saveButton.bounds.size.height) / -2, 0);
+  CGFloat verticalInset = (48 - CGRectGetHeight(self.saveButton.bounds)) / -2;
+  self.saveButton.hitAreaInsets = UIEdgeInsetsMake(verticalInset, 0, verticalInset, 0);
 }
 
 #pragma mark - UITextFieldDelegate methods

--- a/MDC-111/ObjectiveC/Complete/MDC-111/ViewController.m
+++ b/MDC-111/ObjectiveC/Complete/MDC-111/ViewController.m
@@ -70,7 +70,7 @@
 - (void)viewDidLayoutSubviews {
   [super viewDidLayoutSubviews];
 
-  CGFloat verticalInset = (48 - CGRectGetHeight(self.saveButton.bounds)) / -2;
+  CGFloat verticalInset = MIN(0, (CGRectGetHeight(self.saveButton.bounds) - 48) / 2);
   self.saveButton.hitAreaInsets = UIEdgeInsetsMake(verticalInset, 0, verticalInset, 0);
 }
 

--- a/MDC-111/Swift/Complete/MDC-111/ViewController.swift
+++ b/MDC-111/Swift/Complete/MDC-111/ViewController.swift
@@ -49,9 +49,10 @@ class ViewController: UIViewController, UITextFieldDelegate {
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
 
-    saveButton.hitAreaInsets = UIEdgeInsets(top: (48 - self.saveButton.bounds.height) / -2,
+    let verticalInset = min(0, (self.saveButton.bounds.height - 48) / 2)
+    saveButton.hitAreaInsets = UIEdgeInsets(top: verticalInset,
                                             left: 0,
-                                            bottom: (48 - self.saveButton.bounds.height) / -2,
+                                            bottom: verticalInset,
                                             right: 0)
   }
 

--- a/MDC-111/Swift/Complete/MDC-111/ViewController.swift
+++ b/MDC-111/Swift/Complete/MDC-111/ViewController.swift
@@ -49,9 +49,9 @@ class ViewController: UIViewController, UITextFieldDelegate {
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
 
-    saveButton.hitAreaInsets = UIEdgeInsets(top: (48 - self.saveButton.bounds.size.height) / -2,
+    saveButton.hitAreaInsets = UIEdgeInsets(top: (48 - self.saveButton.bounds.height) / -2,
                                             left: 0,
-                                            bottom: (48 - self.saveButton.bounds.size.height) / -2,
+                                            bottom: (48 - self.saveButton.bounds.height) / -2,
                                             right: 0)
   }
 


### PR DESCRIPTION
In MDC-111 codelab we were using `self.bounds.size.height` instead of `self.bounds.height` or `CGRectGetHeight(self.bounds)` this fixes that.