### PR TITLE
Update Swift 101 to use MDCButton

### DIFF
--- a/MDC-101/Swift/Complete/Shrine/Shrine/LoginViewController.swift
+++ b/MDC-101/Swift/Complete/Shrine/Shrine/LoginViewController.swift
@@ -64,15 +64,15 @@ class LoginViewController: UIViewController {
 
   // Buttons
   //TODO: Add buttons
-  let cancelButton: MDCFlatButton = {
-    let cancelButton = MDCFlatButton()
+  let cancelButton: MDCButton = {
+    let cancelButton = MDCButton()
     cancelButton.translatesAutoresizingMaskIntoConstraints = false
     cancelButton.setTitle("CANCEL", for: .normal)
     cancelButton.addTarget(self, action: #selector(didTapCancel(sender:)), for: .touchUpInside)
     return cancelButton
   }()
-  let nextButton: MDCRaisedButton = {
-    let nextButton = MDCRaisedButton()
+  let nextButton: MDCButton = {
+    let nextButton = MDCButton()
     nextButton.translatesAutoresizingMaskIntoConstraints = false
     nextButton.setTitle("NEXT", for: .normal)
     nextButton.addTarget(self, action: #selector(didTapNext(sender:)), for: .touchUpInside)


### PR DESCRIPTION
This PR removes the usage of MDCFlatButton and MDCRaiseButton within codelab 101

# Complete
| Before | After |
| - | - |
|![iPhone6s101CompleteBefore](https://user-images.githubusercontent.com/7131294/54433774-0839f200-4703-11e9-811a-711b8930786b.png)|![iPhone6s101Swift](https://user-images.githubusercontent.com/7131294/54433787-0e2fd300-4703-11e9-96e3-8a6694423b3f.png)|

# Starter
Doesn't have buttons

