### PR TITLE
Update Swift 102

### DIFF
--- a/MDC-102/Swift/Complete/Shrine/Shrine/LoginViewController.swift
+++ b/MDC-102/Swift/Complete/Shrine/Shrine/LoginViewController.swift
@@ -61,15 +61,15 @@ class LoginViewController: UIViewController {
   let passwordTextFieldController: MDCTextInputControllerOutlined
 
   // Buttons
-  let cancelButton: MDCFlatButton = {
-    let cancelButton = MDCFlatButton()
+  let cancelButton: MDCButton = {
+    let cancelButton = MDCButton()
     cancelButton.translatesAutoresizingMaskIntoConstraints = false
     cancelButton.setTitle("CANCEL", for: .normal)
     cancelButton.addTarget(self, action: #selector(didTapCancel(sender:)), for: .touchUpInside)
     return cancelButton
   }()
-  let nextButton: MDCRaisedButton = {
-    let nextButton = MDCRaisedButton()
+  let nextButton: MDCButton = {
+    let nextButton = MDCButton()
     nextButton.translatesAutoresizingMaskIntoConstraints = false
     nextButton.setTitle("NEXT", for: .normal)
     nextButton.addTarget(self, action: #selector(didTapNext(sender:)), for: .touchUpInside)

--- a/MDC-102/Swift/Starter/Shrine/Shrine/LoginViewController.swift
+++ b/MDC-102/Swift/Starter/Shrine/Shrine/LoginViewController.swift
@@ -61,15 +61,15 @@ class LoginViewController: UIViewController {
   let passwordTextFieldController: MDCTextInputControllerOutlined
 
   // Buttons
-  let cancelButton: MDCFlatButton = {
-    let cancelButton = MDCFlatButton()
+  let cancelButton: MDCButton = {
+    let cancelButton = MDCButton()
     cancelButton.translatesAutoresizingMaskIntoConstraints = false
     cancelButton.setTitle("CANCEL", for: .normal)
     cancelButton.addTarget(self, action: #selector(didTapCancel(sender:)), for: .touchUpInside)
     return cancelButton
   }()
-  let nextButton: MDCRaisedButton = {
-    let nextButton = MDCRaisedButton()
+  let nextButton: MDCButton = {
+    let nextButton = MDCButton()
     nextButton.translatesAutoresizingMaskIntoConstraints = false
     nextButton.setTitle("NEXT", for: .normal)
     nextButton.addTarget(self, action: #selector(didTapNext(sender:)), for: .touchUpInside)


### PR DESCRIPTION
Update Swift 102 codelab to use MDCButton instead of MDCFlatButton and MDCRaisedButton

# Starter
| Before | After |
| - | - |
|![iPhone6s102SwiftStarterBefore](https://user-images.githubusercontent.com/7131294/54433322-f146d000-4701-11e9-8005-9b23f002b3bf.png)|![iPhone6s102SwiftStarter](https://user-images.githubusercontent.com/7131294/54433340-fc99fb80-4701-11e9-9032-6a04209d637d.png)|

# Complete 
| Before | After |
| - | - |
|![iPhone6s102SwiftCompleteBefore](https://user-images.githubusercontent.com/7131294/54433366-0d4a7180-4702-11e9-9bf6-6fa8603a9f2e.png)|![iPhone6s102SwiftComplete](https://user-images.githubusercontent.com/7131294/54433378-150a1600-4702-11e9-96a1-0730a43a709f.png)|



