### PR TITLE
Use MDCAppBarViewController instead of MDCAppBar directly

### DIFF
--- a/MDC-102/ObjectiveC/Complete/Shrine/Shrine/HomeViewController.m
+++ b/MDC-102/ObjectiveC/Complete/Shrine/Shrine/HomeViewController.m
@@ -28,8 +28,8 @@
 @property (nonatomic) BOOL shouldDisplayLogin;
 
 // AppBar Property
-//TODO: Add AppBar Property
-@property(nonatomic, strong) MDCAppBar *appBar;
+//TODO: Add AppBarViewController Property
+@property(nonatomic, strong) MDCAppBarViewController *appBarViewController;
 
 @end
 
@@ -47,12 +47,14 @@
   [self displayLogin];
 
   // AppBar Init
-  //TODO: Instantiate and add the AppBar
-  self.appBar = [[MDCAppBar alloc] init];
-  [self addChildViewController:_appBar.headerViewController];
+  //TODO: Instantiate and add the AppBarViewController
+  self.appBarViewController = [[MDCAppBarViewController alloc] init];
+  [self addChildViewController:self.appBarViewController];
+  [self.view addSubview:self.appBarViewController.view];
+  [self.appBarViewController didMoveToParentViewController:self];
+
   // Set the tracking scroll view.
-  self.appBar.headerViewController.headerView.trackingScrollView = self.collectionView;
-  [self.appBar addSubviewsToParent];
+  self.appBarViewController.headerView.trackingScrollView = self.collectionView;
 
   // Setup Navigation Items
   //TODO: Add navigation items
@@ -154,19 +156,19 @@
 
 // TODO: Add scrollview delegate methods to forward scrolling messages
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-  if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-    [self.appBar.headerViewController.headerView trackingScrollViewDidScroll];
+  if (scrollView == self.appBarViewController.headerView.trackingScrollView) {
+    [self.appBarViewController.headerView trackingScrollViewDidScroll];
   }
 }
 
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
-  if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-    [self.appBar.headerViewController.headerView trackingScrollViewDidEndDecelerating];
+  if (scrollView == self.appBarViewController.headerView.trackingScrollView) {
+    [self.appBarViewController.headerView trackingScrollViewDidEndDecelerating];
   }
 }
 
 - (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
+  MDCFlexibleHeaderView *headerView = self.appBarViewController.headerView;
   if (scrollView == headerView.trackingScrollView) {
     [headerView trackingScrollViewDidEndDraggingWillDecelerate:decelerate];
   }
@@ -175,7 +177,7 @@
 - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView
                      withVelocity:(CGPoint)velocity
               targetContentOffset:(inout CGPoint *)targetContentOffset {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
+  MDCFlexibleHeaderView *headerView = self.appBarViewController.headerView;
   if (scrollView == headerView.trackingScrollView) {
     [headerView trackingScrollViewWillEndDraggingWithVelocity:velocity
                                           targetContentOffset:targetContentOffset];

--- a/MDC-102/ObjectiveC/Starter/Shrine/Shrine/HomeViewController.m
+++ b/MDC-102/ObjectiveC/Starter/Shrine/Shrine/HomeViewController.m
@@ -28,7 +28,7 @@
 @property (nonatomic) BOOL shouldDisplayLogin;
 
 // AppBar Property
-//TODO: Add AppBar Property
+//TODO: Add AppBarViewController Property
 
 @end
 

--- a/MDC-102/Swift/Complete/Shrine/Shrine/HomeViewController.swift
+++ b/MDC-102/Swift/Complete/Shrine/Shrine/HomeViewController.swift
@@ -20,8 +20,8 @@ import MaterialComponents
 
 class HomeViewController: UICollectionViewController {
   var shouldDisplayLogin = true
-  //TODO: Add an appBar property
-  var appBar = MDCAppBar()
+  //TODO: Add an appBarViewController property
+  var appBarViewController = MDCAppBarViewController()
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -35,9 +35,12 @@ class HomeViewController: UICollectionViewController {
 
     // AppBar Setup
     //TODO: Add the appBar controller and views
-    self.addChildViewController(appBar.headerViewController)
-    self.appBar.headerViewController.headerView.trackingScrollView = self.collectionView
-    appBar.addSubviewsToParent()
+    self.addChildViewController(self.appBarViewController)
+    self.view.addSubview(self.appBarViewController.view)
+    self.appBarViewController.didMove(toParentViewController: self)
+
+    // Set the tracking scroll view.
+    self.appBarViewController.headerView.trackingScrollView = self.collectionView
 
     // Setup Navigation Items
     //TODO: Create the items and set them on the view controller's navigationItems properties
@@ -121,20 +124,20 @@ class HomeViewController: UICollectionViewController {
 extension HomeViewController {
 
   override func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-      self.appBar.headerViewController.headerView.trackingScrollDidScroll()
+    if (scrollView == self.appBarViewController.headerView.trackingScrollView) {
+      self.appBarViewController.headerView.trackingScrollDidScroll()
     }
   }
 
   override func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-    if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-      self.appBar.headerViewController.headerView.trackingScrollDidEndDecelerating()
+    if (scrollView == self.appBarViewController.headerView.trackingScrollView) {
+      self.appBarViewController.headerView.trackingScrollDidEndDecelerating()
     }
   }
 
   override func scrollViewDidEndDragging(_ scrollView: UIScrollView,
                                          willDecelerate decelerate: Bool) {
-    let headerView = self.appBar.headerViewController.headerView
+    let headerView = self.appBarViewController.headerView
     if (scrollView == headerView.trackingScrollView) {
       headerView.trackingScrollDidEndDraggingWillDecelerate(decelerate)
     }
@@ -143,7 +146,7 @@ extension HomeViewController {
   override func scrollViewWillEndDragging(_ scrollView: UIScrollView,
                                           withVelocity velocity: CGPoint,
                                           targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-    let headerView = self.appBar.headerViewController.headerView
+    let headerView = self.appBarViewController.headerView
     if (scrollView == headerView.trackingScrollView) {
       headerView.trackingScrollWillEndDragging(withVelocity: velocity,
                                                targetContentOffset: targetContentOffset)

--- a/MDC-102/Swift/Starter/Shrine/Shrine/HomeViewController.swift
+++ b/MDC-102/Swift/Starter/Shrine/Shrine/HomeViewController.swift
@@ -20,7 +20,7 @@ import MaterialComponents
 
 class HomeViewController: UICollectionViewController {
   var shouldDisplayLogin = true
-  //TODO: Add an appBar property
+  //TODO: Add an appBarViewController property
 
   override func viewDidLoad() {
     super.viewDidLoad()

--- a/MDC-103/ObjectiveC/Complete/Shrine/Shrine/HomeViewController.m
+++ b/MDC-103/ObjectiveC/Complete/Shrine/Shrine/HomeViewController.m
@@ -32,8 +32,8 @@
 
 @property (nonatomic) BOOL shouldDisplayLogin;
 
-// AppBar Property
-@property(nonatomic, strong) MDCAppBar *appBar;
+// AppBarViewController Property
+@property(nonatomic, strong) MDCAppBarViewController *appBarViewController;
 
 @end
 
@@ -50,12 +50,14 @@
   // Display the Login Screen the first time this controller is shown
   [self displayLogin];
 
-  // AppBar Init
-  _appBar = [[MDCAppBar alloc] init];
-  [self addChildViewController:_appBar.headerViewController];
+  // AppBarViewController Init
+  self.appBarViewController = [[MDCAppBarViewController alloc] init];
+  [self addChildViewController:self.appBarViewController];
+  [self.view addSubview:self.appBarViewController.view];
+  [self.appBarViewController didMoveToParentViewController:self];
+  
   // Set the tracking scroll view.
-  self.appBar.headerViewController.headerView.trackingScrollView = self.collectionView;
-  [self.appBar addSubviewsToParent];
+  self.appBarViewController.headerView.trackingScrollView = self.collectionView;
 
   // Setup Navigation Items
   UIImage *menuItemImage = [UIImage imageNamed:@"MenuItem"];
@@ -88,13 +90,13 @@
   id<MDCColorScheming> colorScheme = [ApplicationScheme sharedInstance].colorScheme;
   self.view.backgroundColor = colorScheme.surfaceColor;
   self.collectionView.backgroundColor = colorScheme.surfaceColor;
-  [MDCAppBarColorThemer applySemanticColorScheme:colorScheme
-                                        toAppBar:self.appBar];
+  [MDCAppBarColorThemer applyColorScheme:colorScheme
+                  toAppBarViewController:self.appBarViewController];
 
   // TODO: Theme our interface with our typography
   id<MDCTypographyScheming> typographyScheme = [ApplicationScheme sharedInstance].typographyScheme;
   [MDCAppBarTypographyThemer applyTypographyScheme:typographyScheme
-                                          toAppBar:self.appBar];
+                            toAppBarViewController:self.appBarViewController];
 
   // TODO: Set layout to our custom layout
   self.collectionView.collectionViewLayout = [[CustomLayout alloc] init];
@@ -145,19 +147,19 @@
 // the Flexible Header's behavior.
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-  if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-    [self.appBar.headerViewController.headerView trackingScrollViewDidScroll];
+  if (scrollView == self.appBarViewController.headerView.trackingScrollView) {
+    [self.appBarViewController.headerView trackingScrollViewDidScroll];
   }
 }
 
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
-  if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-    [self.appBar.headerViewController.headerView trackingScrollViewDidEndDecelerating];
+  if (scrollView == self.appBarViewController.headerView.trackingScrollView) {
+    [self.appBarViewController.headerView trackingScrollViewDidEndDecelerating];
   }
 }
 
 - (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
+  MDCFlexibleHeaderView *headerView = self.appBarViewController.headerView;
   if (scrollView == headerView.trackingScrollView) {
     [headerView trackingScrollViewDidEndDraggingWillDecelerate:decelerate];
   }
@@ -166,7 +168,7 @@
 - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView
                      withVelocity:(CGPoint)velocity
               targetContentOffset:(inout CGPoint *)targetContentOffset {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
+  MDCFlexibleHeaderView *headerView = self.appBarViewController.headerView;
   if (scrollView == headerView.trackingScrollView) {
     [headerView trackingScrollViewWillEndDraggingWithVelocity:velocity
                                           targetContentOffset:targetContentOffset];

--- a/MDC-103/ObjectiveC/Starter/Shrine/Shrine/HomeViewController.m
+++ b/MDC-103/ObjectiveC/Starter/Shrine/Shrine/HomeViewController.m
@@ -33,7 +33,7 @@
 @property (nonatomic) BOOL shouldDisplayLogin;
 
 // AppBar Property
-@property(nonatomic, strong) MDCAppBar *appBar;
+@property(nonatomic, strong) MDCAppBarViewController *appBarViewController;
 
 @end
 
@@ -51,11 +51,13 @@
   [self displayLogin];
 
   // AppBar Init
-  _appBar = [[MDCAppBar alloc] init];
-  [self addChildViewController:_appBar.headerViewController];
+  self.appBarViewController = [[MDCAppBarViewController alloc] init];
+  [self addChildViewController:self.appBarViewController];
+  [self.view addSubview:self.appBarViewController.view];
+  [self.appBarViewController didMoveToParentViewController:self];
+  
   // Set the tracking scroll view.
-  self.appBar.headerViewController.headerView.trackingScrollView = self.collectionView;
-  [self.appBar addSubviewsToParent];
+  self.appBarViewController.headerView.trackingScrollView = self.collectionView;
 
   // Setup Navigation Items
   UIImage *menuItemImage = [UIImage imageNamed:@"MenuItem"];
@@ -136,19 +138,19 @@
 // the Flexible Header's behavior.
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-  if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-    [self.appBar.headerViewController.headerView trackingScrollViewDidScroll];
+  if (scrollView == self.appBarViewController.headerView.trackingScrollView) {
+    [self.appBarViewController.headerView trackingScrollViewDidScroll];
   }
 }
 
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
-  if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-    [self.appBar.headerViewController.headerView trackingScrollViewDidEndDecelerating];
+  if (scrollView == self.appBarViewController.headerView.trackingScrollView) {
+    [self.appBarViewController.headerView trackingScrollViewDidEndDecelerating];
   }
 }
 
 - (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
+  MDCFlexibleHeaderView *headerView = self.appBarViewController.headerView;
   if (scrollView == headerView.trackingScrollView) {
     [headerView trackingScrollViewDidEndDraggingWillDecelerate:decelerate];
   }
@@ -157,7 +159,7 @@
 - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView
                      withVelocity:(CGPoint)velocity
               targetContentOffset:(inout CGPoint *)targetContentOffset {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
+  MDCFlexibleHeaderView *headerView = self.appBarViewController.headerView;
   if (scrollView == headerView.trackingScrollView) {
     [headerView trackingScrollViewWillEndDraggingWithVelocity:velocity
                                           targetContentOffset:targetContentOffset];

--- a/MDC-103/Swift/Complete/Shrine/Shrine/HomeViewController.swift
+++ b/MDC-103/Swift/Complete/Shrine/Shrine/HomeViewController.swift
@@ -20,7 +20,7 @@ import MaterialComponents
 
 class HomeViewController: UICollectionViewController {
   var shouldDisplayLogin = true
-  var appBar = MDCAppBar()
+  var appBarViewController = MDCAppBarViewController()
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -33,9 +33,12 @@ class HomeViewController: UICollectionViewController {
     self.collectionView?.backgroundColor = .white
 
     // AppBar Init
-    self.addChildViewController(appBar.headerViewController)
-    self.appBar.headerViewController.headerView.trackingScrollView = self.collectionView
-    appBar.addSubviewsToParent()
+    self.addChildViewController(self.appBarViewController)
+    self.view.addSubview(self.appBarViewController.view)
+    self.appBarViewController.didMove(toParentViewController: self)
+
+    // Set the tracking scroll view.
+    self.appBarViewController.headerView.trackingScrollView = self.collectionView
 
     // Setup Navigation Items
     let menuItemImage = UIImage(named: "MenuItem")
@@ -63,10 +66,12 @@ class HomeViewController: UICollectionViewController {
     // TODO: Theme our interface with our colors
     self.view.backgroundColor = ApplicationScheme.shared.colorScheme.surfaceColor
     self.collectionView?.backgroundColor = ApplicationScheme.shared.colorScheme.surfaceColor
-    MDCAppBarColorThemer.applySemanticColorScheme(ApplicationScheme.shared.colorScheme, to:self.appBar)
+    MDCAppBarColorThemer.applyColorScheme(ApplicationScheme.shared.colorScheme,
+                                          to: self.appBarViewController)
 
     // TODO: Theme our interface with our typography
-    MDCAppBarTypographyThemer.applyTypographyScheme(ApplicationScheme.shared.typographyScheme, to: self.appBar)
+    MDCAppBarTypographyThemer.applyTypographyScheme(ApplicationScheme.shared.typographyScheme,
+                                                    to: self.appBarViewController)
 
     // TODO: Set layout to our custom layout
     self.collectionView?.collectionViewLayout = CustomLayout()
@@ -124,20 +129,20 @@ class HomeViewController: UICollectionViewController {
 extension HomeViewController {
 
   override func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-      self.appBar.headerViewController.headerView.trackingScrollDidScroll()
+    if (scrollView == self.appBarViewController.headerView.trackingScrollView) {
+      self.appBarViewController.headerView.trackingScrollDidScroll()
     }
   }
 
   override func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-    if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-      self.appBar.headerViewController.headerView.trackingScrollDidEndDecelerating()
+    if (scrollView == self.appBarViewController.headerView.trackingScrollView) {
+      self.appBarViewController.headerView.trackingScrollDidEndDecelerating()
     }
   }
 
   override func scrollViewDidEndDragging(_ scrollView: UIScrollView,
                                          willDecelerate decelerate: Bool) {
-    let headerView = self.appBar.headerViewController.headerView
+    let headerView = self.appBarViewController.headerView
     if (scrollView == headerView.trackingScrollView) {
       headerView.trackingScrollDidEndDraggingWillDecelerate(decelerate)
     }
@@ -146,7 +151,7 @@ extension HomeViewController {
   override func scrollViewWillEndDragging(_ scrollView: UIScrollView,
                                           withVelocity velocity: CGPoint,
                                           targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-    let headerView = self.appBar.headerViewController.headerView
+    let headerView = self.appBarViewController.headerView
     if (scrollView == headerView.trackingScrollView) {
       headerView.trackingScrollWillEndDragging(withVelocity: velocity,
                                                targetContentOffset: targetContentOffset)

--- a/MDC-103/Swift/Starter/Shrine/Shrine/HomeViewController.swift
+++ b/MDC-103/Swift/Starter/Shrine/Shrine/HomeViewController.swift
@@ -20,7 +20,7 @@ import MaterialComponents
 
 class HomeViewController: UICollectionViewController {
   var shouldDisplayLogin = true
-  var appBar = MDCAppBar()
+  var appBarViewController = MDCAppBarViewController()
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -33,9 +33,12 @@ class HomeViewController: UICollectionViewController {
     self.collectionView?.backgroundColor = .white
 
     // AppBar Init
-    self.addChildViewController(appBar.headerViewController)
-    self.appBar.headerViewController.headerView.trackingScrollView = self.collectionView
-    appBar.addSubviewsToParent()
+    self.addChildViewController(self.appBarViewController)
+    self.view.addSubview(self.appBarViewController.view)
+    self.appBarViewController.didMove(toParentViewController: self)
+    
+    // Set the tracking scroll view.
+    self.appBarViewController.headerView.trackingScrollView = self.collectionView
 
     // Setup Navigation Items
     let menuItemImage = UIImage(named: "MenuItem")
@@ -119,20 +122,20 @@ class HomeViewController: UICollectionViewController {
 extension HomeViewController {
 
   override func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-      self.appBar.headerViewController.headerView.trackingScrollDidScroll()
+    if (scrollView == self.appBarViewController.headerView.trackingScrollView) {
+      self.appBarViewController.headerView.trackingScrollDidScroll()
     }
   }
 
   override func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-    if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-      self.appBar.headerViewController.headerView.trackingScrollDidEndDecelerating()
+    if (scrollView == self.appBarViewController.headerView.trackingScrollView) {
+      self.appBarViewController.headerView.trackingScrollDidEndDecelerating()
     }
   }
 
   override func scrollViewDidEndDragging(_ scrollView: UIScrollView,
                                          willDecelerate decelerate: Bool) {
-    let headerView = self.appBar.headerViewController.headerView
+    let headerView = self.appBarViewController.headerView
     if (scrollView == headerView.trackingScrollView) {
       headerView.trackingScrollDidEndDraggingWillDecelerate(decelerate)
     }
@@ -141,7 +144,7 @@ extension HomeViewController {
   override func scrollViewWillEndDragging(_ scrollView: UIScrollView,
                                           withVelocity velocity: CGPoint,
                                           targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-    let headerView = self.appBar.headerViewController.headerView
+    let headerView = self.appBarViewController.headerView
     if (scrollView == headerView.trackingScrollView) {
       headerView.trackingScrollWillEndDragging(withVelocity: velocity,
                                                targetContentOffset: targetContentOffset)

--- a/MDC-104/ObjectiveC/Complete/Shrine/Shrine/HomeViewController.m
+++ b/MDC-104/ObjectiveC/Complete/Shrine/Shrine/HomeViewController.m
@@ -31,8 +31,8 @@
 
 @property (nonatomic) BOOL shouldDisplayLogin;
 
-// AppBar Property
-@property(nonatomic, strong) MDCAppBar *appBar;
+// AppBarViewController Property
+@property(nonatomic, strong) MDCAppBarViewController *appBarViewController;
 
 @end
 
@@ -47,12 +47,14 @@
   self.title = @"Shrine";
 
   // AppBar Init
-  //TODO: Remove the following five lines to remove the App Bar
-//  _appBar = [[MDCAppBar alloc] init];
-//  [self addChildViewController:_appBar.headerViewController];
-//  // Set the tracking scroll view.
-//  self.appBar.headerViewController.headerView.trackingScrollView = self.collectionView;
-//  [self.appBar addSubviewsToParent];
+  //TODO: Remove the following seven lines to remove the App Bar
+//  self.appBarViewController = [[MDCAppBarViewController alloc] init];
+//  [self addChildViewController:self.appBarViewController];
+//  [self.view addSubview:self.appBarViewController.view];
+//  [self.appBarViewController didMoveToParentViewController:self];
+//
+//  Set the tracking scroll view.
+//  self.appBarViewController.headerView.trackingScrollView = self.collectionView;
 
   // Setup Navigation Items
   UIImage *menuItemImage = [UIImage imageNamed:@"MenuItem"];

--- a/MDC-104/ObjectiveC/Complete/Shrine/Shrine/HomeViewController.m
+++ b/MDC-104/ObjectiveC/Complete/Shrine/Shrine/HomeViewController.m
@@ -84,11 +84,11 @@
   self.navigationItem.rightBarButtonItems = @[ tuneItem, searchItem ];
 
     self.view.backgroundColor = [ApplicationScheme sharedInstance].colorScheme.surfaceColor;
-  [MDCAppBarColorThemer applySemanticColorScheme:[ApplicationScheme sharedInstance].colorScheme
-                                        toAppBar:self.appBar];
+  [MDCAppBarColorThemer applyColorScheme:[ApplicationScheme sharedInstance].colorScheme
+                  toAppBarViewController:self.appBarViewController];
 
   [MDCAppBarTypographyThemer applyTypographyScheme:[ApplicationScheme sharedInstance].typographyScheme
-                                          toAppBar:self.appBar];
+                            toAppBarViewController:self.appBarViewController];
 
   self.collectionView.collectionViewLayout = [[CustomLayout alloc] init];
 
@@ -144,19 +144,19 @@
 // the Flexible Header's behavior.
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-  if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-    [self.appBar.headerViewController.headerView trackingScrollViewDidScroll];
+  if (scrollView == self.appBarViewController.headerView.trackingScrollView) {
+    [self.appBarViewController.headerView trackingScrollViewDidScroll];
   }
 }
 
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
-  if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-    [self.appBar.headerViewController.headerView trackingScrollViewDidEndDecelerating];
+  if (scrollView == self.appBarViewController.headerView.trackingScrollView) {
+    [self.appBarViewController.headerView trackingScrollViewDidEndDecelerating];
   }
 }
 
 - (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
+  MDCFlexibleHeaderView *headerView = self.appBarViewController.headerView;
   if (scrollView == headerView.trackingScrollView) {
     [headerView trackingScrollViewDidEndDraggingWillDecelerate:decelerate];
   }
@@ -165,7 +165,7 @@
 - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView
                      withVelocity:(CGPoint)velocity
               targetContentOffset:(inout CGPoint *)targetContentOffset {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
+  MDCFlexibleHeaderView *headerView = self.appBarViewController.headerView;
   if (scrollView == headerView.trackingScrollView) {
     [headerView trackingScrollViewWillEndDraggingWithVelocity:velocity
                                           targetContentOffset:targetContentOffset];

--- a/MDC-104/ObjectiveC/Starter/Shrine/Shrine/HomeViewController.m
+++ b/MDC-104/ObjectiveC/Starter/Shrine/Shrine/HomeViewController.m
@@ -31,8 +31,8 @@
 
 @property (nonatomic) BOOL shouldDisplayLogin;
 
-// AppBar Property
-@property(nonatomic, strong) MDCAppBar *appBar;
+// AppBarViewController Property
+@property(nonatomic, strong) MDCAppBarViewController *appBarViewController;
 
 @end
 
@@ -47,12 +47,14 @@
   self.title = @"Shrine";
 
   // AppBar Init
-  //TODO: Remove the following five lines to remove the App Bar
-  _appBar = [[MDCAppBar alloc] init];
-  [self addChildViewController:_appBar.headerViewController];
+  //TODO: Remove the following seven lines to remove the App Bar
+  self.appBarViewController = [[MDCAppBarViewController alloc] init];
+  [self addChildViewController:self.appBarViewController];
+  [self.view addSubview:self.appBarViewController.view];
+  [self.appBarViewController didMoveToParentViewController:self];
+  
   // Set the tracking scroll view.
-  self.appBar.headerViewController.headerView.trackingScrollView = self.collectionView;
-  [self.appBar addSubviewsToParent];
+  self.appBarViewController.headerView.trackingScrollView = self.collectionView;
 
   // Setup Navigation Items
   UIImage *menuItemImage = [UIImage imageNamed:@"MenuItem"];
@@ -82,11 +84,10 @@
   self.navigationItem.rightBarButtonItems = @[ tuneItem, searchItem ];
 
     self.view.backgroundColor = [ApplicationScheme sharedInstance].colorScheme.surfaceColor;
-  [MDCAppBarColorThemer applySemanticColorScheme:[ApplicationScheme sharedInstance].colorScheme
-                                        toAppBar:self.appBar];
+  [MDCAppBarColorThemer applyColorScheme:[ApplicationScheme sharedInstance].colorScheme                                                 toAppBarViewController:self.appBarViewController];
 
   [MDCAppBarTypographyThemer applyTypographyScheme:[ApplicationScheme sharedInstance].typographyScheme
-                                          toAppBar:self.appBar];
+                                          toAppBarViewController:self.appBarViewController];
 
   self.collectionView.collectionViewLayout = [[CustomLayout alloc] init];
 
@@ -138,19 +139,19 @@
 // the Flexible Header's behavior.
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-  if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-    [self.appBar.headerViewController.headerView trackingScrollViewDidScroll];
+  if (scrollView == self.appBarViewController.headerView.trackingScrollView) {
+    [self.appBarViewController.headerView trackingScrollViewDidScroll];
   }
 }
 
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
-  if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-    [self.appBar.headerViewController.headerView trackingScrollViewDidEndDecelerating];
+  if (scrollView == self.appBarViewController.headerView.trackingScrollView) {
+    [self.appBarViewController.headerView trackingScrollViewDidEndDecelerating];
   }
 }
 
 - (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
+  MDCFlexibleHeaderView *headerView = self.appBarViewController.headerView;
   if (scrollView == headerView.trackingScrollView) {
     [headerView trackingScrollViewDidEndDraggingWillDecelerate:decelerate];
   }
@@ -159,7 +160,7 @@
 - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView
                      withVelocity:(CGPoint)velocity
               targetContentOffset:(inout CGPoint *)targetContentOffset {
-  MDCFlexibleHeaderView *headerView = self.appBar.headerViewController.headerView;
+  MDCFlexibleHeaderView *headerView = self.appBarViewController.headerView;
   if (scrollView == headerView.trackingScrollView) {
     [headerView trackingScrollViewWillEndDraggingWithVelocity:velocity
                                           targetContentOffset:targetContentOffset];

--- a/MDC-104/Swift/Complete/Shrine/Shrine/HomeViewController.swift
+++ b/MDC-104/Swift/Complete/Shrine/Shrine/HomeViewController.swift
@@ -20,7 +20,7 @@ import MaterialComponents
 
 class HomeViewController: UICollectionViewController {
   var shouldDisplayLogin = false
-  var appBar = MDCAppBar()
+  var appBarViewController = MDCAppBarViewController()
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -33,10 +33,13 @@ class HomeViewController: UICollectionViewController {
     self.collectionView?.backgroundColor = .clear
 
     // AppBar Setup
-    //TODO: Remove AppBar Setup in the following three lines
-//    self.addChildViewController(appBar.headerViewController)
-//    self.appBar.headerViewController.headerView.trackingScrollView = self.collectionView
-//    appBar.addSubviewsToParent()
+    //TODO: Remove AppBar Setup in the following six lines
+//    self.addChildViewController(self.appBarViewController)
+//    self.view.addSubview(self.appBarViewController.view)
+//    self.appBarViewController.didMove(toParentViewController: self)
+//
+//     Set the tracking scroll view.
+//    self.appBarViewController.headerView.trackingScrollView = self.collectionView
 
     // Setup Navigation Items
     let menuItemImage = UIImage(named: "MenuItem")
@@ -61,9 +64,11 @@ class HomeViewController: UICollectionViewController {
                                      action: nil)
     self.navigationItem.rightBarButtonItems = [ tuneItem, searchItem ]
 
-    MDCAppBarColorThemer.applySemanticColorScheme(ApplicationScheme.shared.colorScheme, to:self.appBar)
+    MDCAppBarColorThemer.applyColorScheme(ApplicationScheme.shared.colorScheme,
+                                          to:self.appBarViewController)
 
-    MDCAppBarTypographyThemer.applyTypographyScheme(ApplicationScheme.shared.typographyScheme, to: self.appBar)
+    MDCAppBarTypographyThemer.applyTypographyScheme(ApplicationScheme.shared.typographyScheme,
+                                                    to: self.appBarViewController)
 
     self.collectionView!.collectionViewLayout = CustomLayout()
 
@@ -131,20 +136,20 @@ class HomeViewController: UICollectionViewController {
 extension HomeViewController {
 
   override func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-      self.appBar.headerViewController.headerView.trackingScrollDidScroll()
+    if (scrollView == self.appBarViewController.headerView.trackingScrollView) {
+      self.appBarViewController.headerView.trackingScrollDidScroll()
     }
   }
 
   override func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-    if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-      self.appBar.headerViewController.headerView.trackingScrollDidEndDecelerating()
+    if (scrollView == self.appBarViewController.headerView.trackingScrollView) {
+      self.appBarViewController.headerView.trackingScrollDidEndDecelerating()
     }
   }
 
   override func scrollViewDidEndDragging(_ scrollView: UIScrollView,
                                          willDecelerate decelerate: Bool) {
-    let headerView = self.appBar.headerViewController.headerView
+    let headerView = self.appBarViewController.headerView
     if (scrollView == headerView.trackingScrollView) {
       headerView.trackingScrollDidEndDraggingWillDecelerate(decelerate)
     }
@@ -153,7 +158,7 @@ extension HomeViewController {
   override func scrollViewWillEndDragging(_ scrollView: UIScrollView,
                                           withVelocity velocity: CGPoint,
                                           targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-    let headerView = self.appBar.headerViewController.headerView
+    let headerView = self.appBarViewController.headerView
     if (scrollView == headerView.trackingScrollView) {
       headerView.trackingScrollWillEndDragging(withVelocity: velocity,
                                                targetContentOffset: targetContentOffset)

--- a/MDC-104/Swift/Starter/Shrine/Shrine/HomeViewController.swift
+++ b/MDC-104/Swift/Starter/Shrine/Shrine/HomeViewController.swift
@@ -20,7 +20,7 @@ import MaterialComponents
 
 class HomeViewController: UICollectionViewController {
   var shouldDisplayLogin = false
-  var appBar = MDCAppBar()
+  var appBarViewController = MDCAppBarViewController()
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -33,10 +33,13 @@ class HomeViewController: UICollectionViewController {
     self.collectionView?.backgroundColor = .clear
 
     // AppBar Setup
-    //TODO: Remove AppBar Setup in the following three lines
-    self.addChildViewController(appBar.headerViewController)
-    self.appBar.headerViewController.headerView.trackingScrollView = self.collectionView
-    appBar.addSubviewsToParent()
+    //TODO: Remove AppBar Setup in the following six lines
+    self.addChildViewController(self.appBarViewController)
+    self.view.addSubview(self.appBarViewController.view)
+    self.appBarViewController.didMove(toParentViewController: self)
+    
+    // Set the tracking scroll view.
+    self.appBarViewController.headerView.trackingScrollView = self.collectionView
 
     // Setup Navigation Items
     let menuItemImage = UIImage(named: "MenuItem")
@@ -61,9 +64,11 @@ class HomeViewController: UICollectionViewController {
                                      action: nil)
     self.navigationItem.rightBarButtonItems = [ tuneItem, searchItem ]
 
-    MDCAppBarColorThemer.applySemanticColorScheme(ApplicationScheme.shared.colorScheme, to:self.appBar)
+    MDCAppBarColorThemer.applyColorScheme(ApplicationScheme.shared.colorScheme,
+                                          to:self.appBarViewController)
 
-    MDCAppBarTypographyThemer.applyTypographyScheme(ApplicationScheme.shared.typographyScheme, to: self.appBar)
+    MDCAppBarTypographyThemer.applyTypographyScheme(ApplicationScheme.shared.typographyScheme,
+                                                    to: self.appBarViewController)
 
     self.collectionView!.collectionViewLayout = CustomLayout()
 
@@ -127,20 +132,20 @@ class HomeViewController: UICollectionViewController {
 extension HomeViewController {
 
   override func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-      self.appBar.headerViewController.headerView.trackingScrollDidScroll()
+    if (scrollView == self.appBarViewController.headerView.trackingScrollView) {
+      self.appBarViewController.headerView.trackingScrollDidScroll()
     }
   }
 
   override func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-    if (scrollView == self.appBar.headerViewController.headerView.trackingScrollView) {
-      self.appBar.headerViewController.headerView.trackingScrollDidEndDecelerating()
+    if (scrollView == self.appBarViewController.headerView.trackingScrollView) {
+      self.appBarViewController.headerView.trackingScrollDidEndDecelerating()
     }
   }
 
   override func scrollViewDidEndDragging(_ scrollView: UIScrollView,
                                          willDecelerate decelerate: Bool) {
-    let headerView = self.appBar.headerViewController.headerView
+    let headerView = self.appBarViewController.headerView
     if (scrollView == headerView.trackingScrollView) {
       headerView.trackingScrollDidEndDraggingWillDecelerate(decelerate)
     }
@@ -149,7 +154,7 @@ extension HomeViewController {
   override func scrollViewWillEndDragging(_ scrollView: UIScrollView,
                                           withVelocity velocity: CGPoint,
                                           targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-    let headerView = self.appBar.headerViewController.headerView
+    let headerView = self.appBarViewController.headerView
     if (scrollView == headerView.trackingScrollView) {
       headerView.trackingScrollWillEndDragging(withVelocity: velocity,
                                                targetContentOffset: targetContentOffset)


### PR DESCRIPTION
These changes migrate the MDCAppBar to the MDCAppBarViewController.

Closes https://github.com/material-components/material-components-ios/issues/6879.