### PR TITLE
Bug fix: Bottom App Bar incorrect offset

### DIFF
--- a/MDC-111/ObjectiveC/Starter/Pods/MaterialComponents/components/BottomAppBar/src/private/MDCBottomAppBarAttributes.h
+++ b/MDC-111/ObjectiveC/Starter/Pods/MaterialComponents/components/BottomAppBar/src/private/MDCBottomAppBarAttributes.h
@@ -19,7 +19,7 @@ static const CGFloat kMDCBottomAppBarHeight = 96;
 
 // The offset from the top of the navigation view of the bottom app bar to the
 // bottom app bar position
-static const CGFloat kMDCBottomAppBarNavigationViewYOffset = 38;
+static const CGFloat kMDCBottomAppBarNavigationViewYOffset = 0;
 
 // The horizontal position of the center of the floating button when in leading or trailing state.
 static const CGFloat kMDCBottomAppBarFloatingButtonPositionX = 64;


### PR DESCRIPTION
When adding the Bottom App Bar to a view AND setting the value for `isFloatingButtonHidden` to `true`, the Bottom App Bar is shifted down 38px, and cannot be placed in the correct position without setting this value to 0.

This problem was discovered on iOS 13.1, iPhone 8+

In the picture below, the Bottom App Bar was added, and was pinned to the leading, trailing, and bottom edge of the superview, with a height of 56.

Before: `static const CGFloat kMDCBottomAppBarNavigationViewYOffset = 0;`
![Screen Shot 2019-10-11 at 11 01 48 AM](https://user-images.githubusercontent.com/22397747/66670268-984b0600-ec16-11e9-9d4f-d877abbbac8d.png)

After: `static const CGFloat kMDCBottomAppBarNavigationViewYOffset = 0;`
![Screen Shot 2019-10-11 at 11 02 52 AM](https://user-images.githubusercontent.com/22397747/66670326-b3b61100-ec16-11e9-89c2-d817a7ad3136.png)
